### PR TITLE
add presentation layer sample

### DIFF
--- a/lib/features/auth/data/repository/auth_repository.dart
+++ b/lib/features/auth/data/repository/auth_repository.dart
@@ -1,11 +1,22 @@
 import 'package:flutter_app/features/auth/domain/app_user.dart';
+import 'package:flutter_app/utils/in_memory_store.dart';
 
-abstract class AuthRepository {
-  /// returns null if the user is not signed in
-  AppUser? get currentUser;
+class FakeAuthRepository {
+  final _authState = InMemoryStore<AppUser?>(null);
 
-  /// useful to watch auth state changes in realtime
-  Stream<AppUser?> authStateChanges();
+  Stream<AppUser?> authStateChanges() => _authState.stream;
+  AppUser? get currentUser => _authState.value;
 
-  // other sign in methods
+  Future<void> signInAnonymously() async {
+    await Future.delayed(const Duration(seconds: 3));
+    _authState.value = AppUser(
+      uid: '123', // TODO: make it unique
+    );
+  }
+
+  Future<void> signOut() async {
+    _authState.value = null;
+  }
+
+  void dispose() => _authState.close();
 }

--- a/lib/features/auth/presentation/account_page.dart
+++ b/lib/features/auth/presentation/account_page.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_app/providers/controller_providers.dart';
+import 'package:flutter_app/utils/async_value_ui.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Simple account screen showing some user info and a logout button.
+class AccountPage extends ConsumerWidget {
+  const AccountPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen<AsyncValue>(
+      accountPageControllerProvider,
+      (_, state) => state.showSnackbarOnError(context),
+    );
+    final state = ref.watch(accountPageControllerProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: state.isLoading
+            ? const CircularProgressIndicator()
+            : const Text('Account'),
+        actions: [
+          TextButton(
+            onPressed: state.isLoading
+                ? null
+                : () async {
+                    ref.read(accountPageControllerProvider.notifier).signOut();
+                  },
+            child: Text(
+              'Logout',
+              style: Theme.of(context)
+                  .textTheme
+                  .headline6!
+                  .copyWith(color: Colors.white),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/account_page_controller.dart
+++ b/lib/features/auth/presentation/account_page_controller.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_app/features/auth/data/repository/auth_repository.dart';
+import 'package:flutter_app/providers/repository_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class AccountPageController extends StateNotifier<AsyncValue<void>> {
+  AccountPageController({required this.authRepository})
+      : super(const AsyncData(null));
+  final FakeAuthRepository authRepository;
+
+  Future<void> signOut() async {
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(authRepository.signOut);
+  }
+}

--- a/lib/features/auth/presentation/auth_page.dart
+++ b/lib/features/auth/presentation/auth_page.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_app/features/auth/presentation/account_page.dart';
+import 'package:flutter_app/features/auth/presentation/sign_in_page.dart';
+import 'package:flutter_app/providers/repository_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class AuthPage extends ConsumerWidget {
+  const AuthPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final authState = ref.watch(authStateChangesProvider);
+    return authState.maybeWhen(
+      data: (user) => user != null ? const AccountPage() : const SignInPage(),
+      // TODO: Should also handle errors
+      orElse: () => Scaffold(
+        appBar: AppBar(),
+        body: const Center(child: CircularProgressIndicator()),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/sign_in_page.dart
+++ b/lib/features/auth/presentation/sign_in_page.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_app/providers/controller_providers.dart';
+import 'package:flutter_app/utils/async_value_ui.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class SignInPage extends ConsumerWidget {
+  const SignInPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.listen<AsyncValue>(
+      signInPageControllerProvider,
+      (_, state) => state.showSnackbarOnError(context),
+    );
+    final state = ref.watch(signInPageControllerProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Sign In'),
+      ),
+      body: Center(
+        child: SizedBox(
+          width: 200,
+          height: 50,
+          child: ElevatedButton(
+            onPressed: state.isLoading
+                ? null
+                : () => ref
+                    .read(signInPageControllerProvider.notifier)
+                    .signInAnonymously(),
+            child: state.isLoading
+                ? const CircularProgressIndicator()
+                : const Text('Sign in anonymously'),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/sign_in_page_controller.dart
+++ b/lib/features/auth/presentation/sign_in_page_controller.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_app/features/auth/data/repository/auth_repository.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class SignInPageController extends StateNotifier<AsyncValue<void>> {
+  SignInPageController({required this.authRepository})
+      : super(const AsyncData(null));
+  final FakeAuthRepository authRepository;
+
+  Future<void> signInAnonymously() async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(authRepository.signInAnonymously);
+  }
+}

--- a/lib/features/weather_page/presentation/controllers/current_weather_controller.dart
+++ b/lib/features/weather_page/presentation/controllers/current_weather_controller.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_app/features/weather_page/data/repository/weather_repository.dart';
 import 'package:flutter_app/features/weather_page/domain/weather/weather_data.dart';
 import 'package:flutter_app/features/weather_page/presentation/widgets/subviews/city_search_box.dart';
-import 'package:flutter_app/providers/providers.dart';
+import 'package:flutter_app/providers/repository_providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class CurrentWeatherController extends StateNotifier<AsyncValue<WeatherData>> {

--- a/lib/features/weather_page/presentation/controllers/hourly_weather_controller.dart
+++ b/lib/features/weather_page/presentation/controllers/hourly_weather_controller.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_app/features/weather_page/data/repository/weather_repository.dart';
 import 'package:flutter_app/features/weather_page/domain/forecast/forecast_data.dart';
 import 'package:flutter_app/features/weather_page/presentation/widgets/subviews/city_search_box.dart';
-import 'package:flutter_app/providers/providers.dart';
+import 'package:flutter_app/providers/repository_providers.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class HourlyWeatherController extends StateNotifier<AsyncValue<ForecastData>> {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_app/features/auth/presentation/auth_page.dart';
 import 'package:flutter_app/features/weather_page/presentation/widgets/weather_page.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -36,7 +37,8 @@ class MyApp extends StatelessWidget {
           caption: const TextStyle(color: Colors.white70, fontSize: 13),
         ),
       ),
-      home: const WeatherPage(city: 'London'),
+      // home: const WeatherPage(city: 'London'),
+      home: const AuthPage(),
     );
   }
 }

--- a/lib/providers/controller_providers.dart
+++ b/lib/providers/controller_providers.dart
@@ -1,11 +1,30 @@
+import 'package:flutter_app/features/auth/presentation/account_page_controller.dart';
+import 'package:flutter_app/features/auth/presentation/sign_in_page_controller.dart';
 import 'package:flutter_app/features/cart/controller/cart_item_controller.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'repository_providers.dart';
 import 'service_providers.dart';
 
 final shoppingCartItemControllerProvider =
     StateNotifierProvider<ShoppingCartItemController, AsyncValue<void>>((ref) {
   return ShoppingCartItemController(
     cartService: ref.read(cartServiceProvider),
+  );
+});
+
+final accountPageControllerProvider =
+    StateNotifierProvider.autoDispose<AccountPageController, AsyncValue<void>>(
+        (ref) {
+  return AccountPageController(
+    authRepository: ref.watch(authRepositoryProvider),
+  );
+});
+
+final signInPageControllerProvider =
+    StateNotifierProvider.autoDispose<SignInPageController, AsyncValue<void>>(
+        (ref) {
+  return SignInPageController(
+    authRepository: ref.watch(authRepositoryProvider),
   );
 });

--- a/lib/providers/repository_providers.dart
+++ b/lib/providers/repository_providers.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_app/features/auth/data/repository/auth_repository.dart';
+import 'package:flutter_app/features/auth/domain/app_user.dart';
 import 'package:flutter_app/features/cart/data/repository/local_cart_repository.dart';
 import 'package:flutter_app/features/cart/data/repository/remote_cart_repository.dart';
 import 'package:flutter_app/features/weather_page/data/api/api.dart';
@@ -8,9 +9,15 @@ import 'package:http/http.dart' as http;
 
 import '../features/weather_page/data/api/api_keys.dart';
 
-final authRepositoryProvider = Provider<AuthRepository>((ref) {
-  // This should be overridden in main file
-  throw UnimplementedError();
+final authRepositoryProvider = Provider<FakeAuthRepository>((ref) {
+  final auth = FakeAuthRepository();
+  ref.onDispose(() => auth.dispose());
+  return auth;
+});
+
+final authStateChangesProvider = StreamProvider.autoDispose<AppUser?>((ref) {
+  final authRepository = ref.watch(authRepositoryProvider);
+  return authRepository.authStateChanges();
 });
 
 final localCartRepositoryProvider = Provider<LocalCartRepository>((ref) {

--- a/lib/utils/async_value_ui.dart
+++ b/lib/utils/async_value_ui.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+extension AsyncValueUI on AsyncValue {
+  void showSnackbarOnError(BuildContext context) {
+    if (!isRefreshing && hasError) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(error.toString())),
+      );
+    }
+  }
+}

--- a/lib/utils/in_memory_store.dart
+++ b/lib/utils/in_memory_store.dart
@@ -1,0 +1,22 @@
+import 'package:rxdart/rxdart.dart';
+
+/// An in-memory store backed by BehaviorSubject that can be used to
+/// store the data for all the fake repositories in the app.
+class InMemoryStore<T> {
+  InMemoryStore(T initial) : _subject = BehaviorSubject<T>.seeded(initial);
+
+  /// The BehaviorSubject that holds the data
+  final BehaviorSubject<T> _subject;
+
+  /// The output stream that can be used to listen to the data
+  Stream<T> get stream => _subject.stream;
+
+  /// A synchronous getter for the current value
+  T get value => _subject.value;
+
+  /// A setter for updating the value
+  set value(T value) => _subject.add(value);
+
+  /// Don't forget to call this when done
+  void close() => _subject.close();
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   intl: ^0.18.1
   json_annotation: ^4.8.1
   cached_network_image: ^3.2.3
+  rxdart: ^0.27.3
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
#1 
Referred articles: https://codewithandrea.com/articles/flutter-presentation-layer/
![image](https://github.com/trunghvbk/flutter_app/assets/5953693/a2fc2e8f-a4ac-401d-8634-a4345a5b0b2b)
```
By implementing a custom controller class based on StateNotifier, we've separated our business logic from the UI code.

As a result, our widget class is now completely stateless and is only concerned with:

watching state changes and rebuilding as a result (with ref.watch)
responding to user input by calling methods in the controller (with ref.read)
listening to state changes and showing errors if something goes wrong (with ref.listen)
Meanwhile, the job of our controller is to:

talk to the repository on behalf of the widget
emit state changes as needed
And since the controller doesn't depend on any UI code, it can be easily unit tested.

This makes it an ideal place to store any widget-specific business logic.
```